### PR TITLE
fix pour titre des photos sur le modal

### DIFF
--- a/src/View/Picture/index.html.twig
+++ b/src/View/Picture/index.html.twig
@@ -20,7 +20,7 @@
                         <div class="modal-dialog modal-lg" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h3 class="modal-title">Photo {{ img.id }}</h3>
+                                    <h3 class="modal-title">{{ img.picture_name }}</h3>
                                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>

--- a/src/View/Picture/index.html.twig
+++ b/src/View/Picture/index.html.twig
@@ -20,7 +20,7 @@
                         <div class="modal-dialog modal-lg" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h3 class="modal-title">Photo 1</h3>
+                                    <h3 class="modal-title">Photo {{ img.id }}</h3>
                                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>


### PR DESCRIPTION
Ceci est un fix du bug d'affichage qui mettait toujours "Photo 1" en titre de modal.
Désormais le chiffre s'adapte à l'ID de la photo en BDD.